### PR TITLE
Add ADR-3 Dependencies version number declaration in cabal file

### DIFF
--- a/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md
+++ b/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md
@@ -19,7 +19,7 @@ graph LR
 Considering an example case, where `B` and `C` but not `A`, have the same dependencies, we need to encode version ranges twice.
 This results in duplicated entries in `.cabal` file, with duplicated version bounds.
 
-# Considered options
+## Considered options
 
 1. **Using explicit common stanzas, one per dependency.** See for example: https://github.com/input-output-hk/hedgehog-extras/blob/e7f3c9ff967ed6f3b4c8c17013a4e0c2f541e053/hedgehog-extras.cabal#L19
     * **Advantages**
@@ -39,6 +39,8 @@ This results in duplicated entries in `.cabal` file, with duplicated version bou
       * It may be hard to define logical grouping for few unrelated dependencies.
       * In the worst case scenario we'll end up with *one-stanza-per-one-dependency* definition of
         dependencies, when those will be used in different components.
+      * Each common stanza will need to be named.
+        There is a risk the naming will be inconsistent between projects and confusion could occur around that inconsistency and bike-shedding may result from having to deal with those inconsistencies.
 
 1. **Declaring dependencies' bounds everywhere**.
   In the provided example, the version bounds of common dependencies of `A` and `B` should be both defined in
@@ -59,6 +61,8 @@ This results in duplicated entries in `.cabal` file, with duplicated version bou
     * **Disadvantages**
       * In the `B` & `C` case, there will be a duplication of version bounds.
       * Inconsistency in version bounds declaration because of `B` & `C` case.
+      * If there are multiple roots then, then require all those roots would have to have bounds.
+        If one is accidentally missed, it is possible for those bounds to be ignored if only roots without bounds are in the cabal plan, which could lead to the wrong version of the package build built.
 
 1. **Using a configuration language allowing to generate cabal files** like https://github.com/dhall-lang/dhall-to-cabal .
   This way instead of modifying cabal files, one would has to modify configuration file and then regenerate
@@ -69,6 +73,13 @@ This results in duplicated entries in `.cabal` file, with duplicated version bou
       * New development tool with non-zero learning effort required for team members.
       * Additional piece requiring integration in CI.
       * Syntax usually is more verbose than just `.cabal` files itself.
+      * If the cabal file is checked in to git, then PRs are larger because there will be changes in both the alternate file and the cabal file itself.
+        If the cabal file is not checked into git then tools we rely on may not work on the repository. (For example cardano-haskell-packages and source-repository-package stanzas)
+
+## Status quo
+
+Currently is used a mixture of options 2, 3 and 4.
+Most frequently is used an option 3 for libraries maintained by IOG, but also not everywhere.
 
 # Decision
 
@@ -76,7 +87,7 @@ TBD
 
 # Consequences
 
-The adopted version constraints setting policy should be used consistently across all the projects.
+The adopted version constraints setting policy should be used in `cardano-node`, `cardano-api` and `cardano-cli` projects.
 This will allow for less error-prone dependency management.
 
 # References
@@ -84,4 +95,5 @@ This will allow for less error-prone dependency management.
 1. https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-build-depends
 1. [Per-cabal-file `constraints` - Issue in haskell/cabal](https://github.com/haskell/cabal/issues/8912)
 1. https://input-output-hk.github.io/cardano-engineering-handbook/policy/haskell/packaging/versioning.html
+
 

--- a/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md
+++ b/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md
@@ -1,0 +1,87 @@
+# Status
+
+📜 Proposed 2023-05-15
+
+# Context
+
+In a project with multiple packages, in order to provide stable and reproducible builds, there is a need to
+control version bounds of the dependencies used.
+This is done by entering version bounds into the `.cabal` file, like described in [Cabal documentation](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-build-depends).
+Let's consider an example where multiple package *components* (e.g. libraries, internal libraries, test-suites,
+executables) form a more complex dependency graphs like the following one:
+```mermaid
+graph LR
+ B --> A
+ C --> A
+ D --> B
+ D --> C
+```
+Considering an example case, where `B` and `C` but not `A`, have the same dependencies, we need to encode version ranges twice.
+This results in duplicated entries in `.cabal` file, with duplicated version bounds.
+
+# Considered options
+
+1. **Using explicit common stanzas, one per dependency.** See for example: https://github.com/input-output-hk/hedgehog-extras/blob/e7f3c9ff967ed6f3b4c8c17013a4e0c2f541e053/hedgehog-extras.cabal#L19
+    * **Advantages**
+      * Fine grained control over what dependency is included where, with the single place which defines
+        version bounds.
+    * **Disadvantages**
+      * A lot of boilerplate when defining new dependencies.
+
+1. **Moving common dependencies to `common` stanzas, multiple dependencies in one stanza**.
+  This allows for grouping of dependencies between components in order specify version bound only once.
+  For example the same `common` stanza could be reused in `B` and `C` in order to define version bounds in a
+  single place.
+    * **Advantages**
+      * Grouping multiple dependencies together introduces less boilerplate in comparison to the
+        *one-stanza-per-one-dependency* option.
+    * **Disadvantages**
+      * It may be hard to define logical grouping for few unrelated dependencies.
+      * In the worst case scenario we'll end up with *one-stanza-per-one-dependency* definition of
+        dependencies, when those will be used in different components.
+
+1. **Declaring dependencies' bounds everywhere**.
+  In the provided example, the version bounds of common dependencies of `A` and `B` should be both defined in
+  `A` and `B`.
+    * **Advantages**
+      * Makes it easy to remember how to update dependency version everywhere.
+    * **Disadvantages**
+      * It's not hard to overlook one spot when a person updating dependency version is unfamiliar with the
+        rule.
+
+1. **Declaring dependencies' bounds once, as close as possible to the dependency tree root.**
+  In the provided example, the version bounds of common dependencies of `A` and `B` should be only defined in
+  `A`.
+  If dependencies are both present in `B` & `C`, the version bounds should be duplicated in both components.
+    * **Advantages**
+      * Slight de-duplication of version bounds definitions in comparison to duplicated version bounds
+      * Does not require introducing `common` stanzas
+    * **Disadvantages**
+      * In the `B` & `C` case, there will be a duplication of version bounds.
+      * Inconsistency in version bounds declaration because of `B` & `C` case.
+
+1. **Using a configuration language allowing to generate cabal files** like https://github.com/dhall-lang/dhall-to-cabal .
+  This way instead of modifying cabal files, one would has to modify configuration file and then regenerate
+  `.cabal` files from those.
+    * **Advantages**
+      * Very flexible way of configuration, allows for deduplication of cabal files' contents.
+    * **Disadvantages**
+      * New development tool with non-zero learning effort required for team members.
+      * Additional piece requiring integration in CI.
+      * Syntax usually is more verbose than just `.cabal` files itself.
+
+# Decision
+
+TBD
+
+# Consequences
+
+The adopted version constraints setting policy should be used consistently across all the projects.
+This will allow for less error-prone dependency management.
+
+# References
+
+1. https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-build-depends
+1. [Per-cabal-file `constraints` - Issue in haskell/cabal](https://github.com/haskell/cabal/issues/8912)
+1. https://input-output-hk.github.io/cardano-engineering-handbook/policy/haskell/packaging/versioning.html
+

--- a/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md
+++ b/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md
@@ -4,11 +4,11 @@
 
 # Context
 
-In a project with multiple packages, in order to provide stable and reproducible builds, there is a need to
-control version bounds of the dependencies used.
-This is done by entering version bounds into the `.cabal` file, like described in [Cabal documentation](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-build-depends).
-Let's consider an example where multiple package *components* (e.g. libraries, internal libraries, test-suites,
-executables) form a more complex dependency graphs like the following one:
+In a project with multiple packages, there is a need to control version bounds of the dependencies used to provide stable and reproducible builds. This is achieved by entering version bounds into the `.cabal` file, as described in [Cabal documentation](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-build-depends).
+
+Let's consider an example where multiple package *components* (eg, libraries, internal libraries, test-suites,
+executables) form a more complex dependency graph like the following one:
+
 ```mermaid
 graph LR
  B --> A
@@ -17,28 +17,27 @@ graph LR
  D --> C
 ```
 Considering an example case, where `B` and `C` but not `A`, have the same dependencies, we need to encode version ranges twice.
-This results in duplicated entries in `.cabal` file, with duplicated version bounds.
+This results in duplicated entries in the `.cabal` file, with duplicated version bounds.
 
 ## Considered options
 
-1. **Using explicit common stanzas, one per dependency.** See for example: https://github.com/input-output-hk/hedgehog-extras/blob/e7f3c9ff967ed6f3b4c8c17013a4e0c2f541e053/hedgehog-extras.cabal#L19
+1. **Using explicit common stanzas, one per dependency.** See [the example](https://github.com/input-output-hk/hedgehog-extras/blob/e7f3c9ff967ed6f3b4c8c17013a4e0c2f541e053/hedgehog-extras.cabal#L19)
     * **Advantages**
-      * Fine grained control over what dependency is included where, with the single place which defines
-        version bounds.
+      * Fine-grained control over what dependency is included where is achieved with a single place defining version bounds
     * **Disadvantages**
-      * A lot of boilerplate when defining new dependencies.
+      * A lot of boilerplate when defining new dependencies
 
 1. **Moving common dependencies to `common` stanzas, multiple dependencies in one stanza**.
-  This allows for grouping of dependencies between components in order specify version bound only once.
-  For example the same `common` stanza could be reused in `B` and `C` in order to define version bounds in a
+  This allows for the grouping of dependencies between components in order to specify version bound only once.
+  For example, the same `common` stanza could be reused in `B` and `C` to define version bounds in a
   single place.
     * **Advantages**
       * Grouping multiple dependencies together introduces less boilerplate in comparison to the
-        *one-stanza-per-one-dependency* option.
+        *one-stanza-per-one-dependency* option
     * **Disadvantages**
-      * It may be hard to define logical grouping for few unrelated dependencies.
-      * In the worst case scenario we'll end up with *one-stanza-per-one-dependency* definition of
-        dependencies, when those will be used in different components.
+      * It may be hard to define logical grouping for a few unrelated dependencies
+      * In the worst-case scenario we'll end up with *one-stanza-per-one-dependency* definition of
+        dependencies, when those will be used in different components
       * Each common stanza will need to be named.
         There is a risk the naming will be inconsistent between projects and confusion could occur around that inconsistency and bike-shedding may result from having to deal with those inconsistencies.
 
@@ -46,40 +45,37 @@ This results in duplicated entries in `.cabal` file, with duplicated version bou
   In the provided example, the version bounds of common dependencies of `A` and `B` should be both defined in
   `A` and `B`.
     * **Advantages**
-      * Makes it easy to remember how to update dependency version everywhere.
+      * Makes it easy to remember how to update dependency versions everywhere
     * **Disadvantages**
-      * It's not hard to overlook one spot when a person updating dependency version is unfamiliar with the
-        rule.
+      * It's not hard to overlook a spot when a person updating the dependency version is unfamiliar with the
+        rule
 
 1. **Declaring dependencies' bounds once, as close as possible to the dependency tree root.**
   In the provided example, the version bounds of common dependencies of `A` and `B` should be only defined in
   `A`.
-  If dependencies are both present in `B` & `C`, the version bounds should be duplicated in both components.
+  If dependencies are both present in `B` and `C`, the version bounds should be duplicated in both components.
     * **Advantages**
       * Slight de-duplication of version bounds definitions in comparison to duplicated version bounds
       * Does not require introducing `common` stanzas
     * **Disadvantages**
-      * In the `B` & `C` case, there will be a duplication of version bounds.
-      * Inconsistency in version bounds declaration because of `B` & `C` case.
-      * If there are multiple roots then, then require all those roots would have to have bounds.
-        If one is accidentally missed, it is possible for those bounds to be ignored if only roots without bounds are in the cabal plan, which could lead to the wrong version of the package build built.
+      * In the `B` & `C` cases, there will be a duplication of version bounds
+      * Inconsistency in version bounds declaration because of `B` & `C` cases
+      * If there are multiple roots, then all those roots would have to have bounds. If one is accidentally missed, it is possible for those bounds to be ignored if only roots without bounds are in the Cabal plan, which could lead to the wrong version of the package being built.
 
-1. **Using a configuration language allowing to generate cabal files** like https://github.com/dhall-lang/dhall-to-cabal .
-  This way instead of modifying cabal files, one would has to modify configuration file and then regenerate
-  `.cabal` files from those.
+1. **Using a configuration language allowing to generate Cabal files** like https://github.com/dhall-lang/dhall-to-cabal .
+ This way, instead of modifying Cabal files, one would have to modify the configuration file and then regenerate `.cabal` files from it.
     * **Advantages**
-      * Very flexible way of configuration, allows for deduplication of cabal files' contents.
+      * A flexible way of configuration, which allows for deduplication of Cabal files' contents
     * **Disadvantages**
-      * New development tool with non-zero learning effort required for team members.
-      * Additional piece requiring integration in CI.
-      * Syntax usually is more verbose than just `.cabal` files itself.
-      * If the cabal file is checked in to git, then PRs are larger because there will be changes in both the alternate file and the cabal file itself.
-        If the cabal file is not checked into git then tools we rely on may not work on the repository. (For example cardano-haskell-packages and source-repository-package stanzas)
+      * New development tool with non-zero learning effort required for team members
+      * Additional piece requiring integration in CI
+      * Syntax usually is more verbose than just `.cabal` files itself
+      * If the Cabal file is checked into git, PRs are larger because there will be changes in both the alternate file and the Cabal file itself.
+        If the Cabal file is not checked into git, the tools we rely on may not work in the repository. (For example, see cardano-haskell-packages and source-repository-package stanzas)
 
 ## Status quo
 
-Currently is used a mixture of options 2, 3 and 4.
-Most frequently is used an option 3 for libraries maintained by IOG, but also not everywhere.
+Currently, a mixture of options 2, 3, and 4 is used. Most frequently, option 3 is used for libraries maintained by IOG, but it is not used everywhere.
 
 # Decision
 
@@ -87,7 +83,7 @@ TBD
 
 # Consequences
 
-The adopted version constraints setting policy should be used in `cardano-node`, `cardano-api` and `cardano-cli` projects.
+The adopted version constraints setting policy should be used in `cardano-node`, `cardano-api`, and `cardano-cli` projects.
 This will allow for less error-prone dependency management.
 
 # References

--- a/docs/Architecture-Decision-Records.md
+++ b/docs/Architecture-Decision-Records.md
@@ -2,6 +2,7 @@
 * ✅ [[ADR-0 Documenting Architecture Decisions]]
 * ✅ [[ADR-1 Default eras for CLI commands]]
 * ✅ [[ADR-2 Module structure for generators]]
+* 📜 [[ADR-3 Dependencies version constraints in cabal file]]
 
 ## Legend
 


### PR DESCRIPTION
This PR is a proposed ADR with cabal dependencies' version numbering. Hopefully after accepting this ADR we will establish a single convention for defining version bounds in cabal files.

Rendered version: https://github.com/input-output-hk/cardano-node-wiki/blob/mgalazyn/doc/adr3-cabal-version-numbering/docs/ADR-3-Dependencies-version-constraints-in-cabal-file.md