### PR TITLE
More clarification on the valency parameter in understanding-config-files.md

### DIFF
--- a/docs/getting-started/understanding-config-files.md
+++ b/docs/getting-started/understanding-config-files.md
@@ -86,8 +86,8 @@ A minimal version of this file looks like this:
   It will then make efforts to establish a connection with at least one of the resolved IPs.
 
 * `hotValency` or `valency` (deprecated name that can also be used) tells the node the number of connections it should attempt to select from the specified group.
-  If you add multiple entries in the `accessPoints` array, you should update this value accordingly.
-  When DNS address are provided, valency determines the count of resolved IP addresses for which the node should maintain an active (hot) connection.
+  If you add multiple entries in the `accessPoints` array, you should update this value to the number of entries for which the node should maintain an active (hot) connection.
+  When DNS addresses are provided, valency determines the count of resolved IP addresses of all entries together for which the node should maintain an active (hot) connection.
 
 
 - `warmValency` is an optional field, similar to `hotValency`, that informs the node about the number of peers it should maintain as warm.

--- a/docs/getting-started/understanding-config-files.md
+++ b/docs/getting-started/understanding-config-files.md
@@ -85,9 +85,9 @@ A minimal version of this file looks like this:
 * This means that your node will initiate contact with the node at IP `x.x.x.x` on `port 3001` and resolve the DNS domain `y.y.y.y` (provided it exists).
   It will then make efforts to establish a connection with at least one of the resolved IPs.
 
-* `hotValency` tells the node the number of connections it should attempt to select from the specified group.
-  When a DNS address is provided, valency determines the count of resolved IP addresses for which the node should maintain an active (hot) connection.
-  Note: one can also use the deprecated now `valency` field for `hotValency`.
+* `hotValency` or `valency` (deprecated name that can also be used) tells the node the number of connections it should attempt to select from the specified group.
+  If you add multiple entries in the `accessPoints` array, you should update this value accordingly.
+  When DNS address are provided, valency determines the count of resolved IP addresses for which the node should maintain an active (hot) connection.
 
 
 - `warmValency` is an optional field, similar to `hotValency`, that informs the node about the number of peers it should maintain as warm.


### PR DESCRIPTION
As an alternative to my proposed changes in https://github.com/input-output-hk/cardano-playground/pull/25, I've updated the info about the `valency` field in a way in which it's more clear to my belief. This because a lot of SPOs seem to forget to update this value to the number of items in the `accessPoints` array when adding access points to it, which is what you want to do in most cases (there were already multiple occurrences of this in the best practices TG group).

The old explanation wasn't wrong or incomplete, but I feel that they might misinterpret it and overlook the fact that there're two cases in which you want to update the `valency` field : when adding more than one entry and/or when using a DNS name that resolves to multiple ip addresses. Therefore I choose to state the first case explicitly.

I've also removed the note and added the old name at the beginning, because the old name is what is used in the examples. An alternative would be to let the note stay at the end, but then you have to be consisted and use the new name `hotValency` in the examples too imho.