### PR TITLE
Adopt ADR-7: CLI Output Presentation

### DIFF
--- a/docs/ADR-7-CLI-Output-Presentation.md
+++ b/docs/ADR-7-CLI-Output-Presentation.md
@@ -1,6 +1,6 @@
 # Status
 
-📜 Proposed 2024-11-13
+✅ Adopted 2024-11-29 
 
 # Context
 


### PR DESCRIPTION
This PR sets the ADR-7 to `Adopted`.

Any comments, changes to `ADR-7` text or vetoes are welcome.

[ADR-7](https://github.com/input-output-hk/cardano-node-wiki/blob/mgalazyn/approve-adr-7/docs/ADR-7-CLI-Output-Presentation.md)