### PR TITLE
Add missing ADR-19 entry to Architecture Decision Records index

### DIFF
--- a/docs/Architecture-Decision-Records.md
+++ b/docs/Architecture-Decision-Records.md
@@ -17,6 +17,7 @@
 * ✅ [ADR-15 JavaScript API for Cardano via WASM-compiled cardano-api](ADR-015-Cardano-API-WASM-library-for-browser)
 * 📜 [ADR-16 cardano-api new TxBodyContent](ADR-016-cardano-api-new-txbodycontent)
 * 📜 [ADR-18 gRPC Server for Cardano Node (cardano-rpc)](ADR-018-cardano-rpc-grpc-server)
+* 📜 [ADR-19 Node Kernel Access for cardano-rpc](ADR-019-node-kernel-access-for-cardano-rpc)
 
 ## Legend
 


### PR DESCRIPTION
ADR-019 (Node Kernel Access for cardano-rpc, added in #94) was never listed in `Architecture-Decision-Records.md` — the index jumps from ADR-18 to nothing. This adds the missing entry with its 📜 Proposed status, matching the existing entry style.
